### PR TITLE
Report XML::Twig version when testing entities (GH#7)

### DIFF
--- a/dancer/t/template.t
+++ b/dancer/t/template.t
@@ -7,6 +7,7 @@ use Test::More tests => 76;
 
 use File::Spec;
 use Data::Dumper;
+use XML::Twig;
 
 use lib File::Spec->catdir( 't', 'lib' );
 
@@ -222,6 +223,8 @@ $resp = dancer_response GET => '/double-dropdown';
 response_content_like $resp,
   qr{<select id="role" name="role"><option value="">Please select role</option><option>1</option><option>2</option><option>3</option><option>4</option></select>},
   "No duplicate for a dropdown with a form";
+
+diag "Testing entities with $XML::Twig::VERSION";
 
 $resp = dancer_response GET => '/ampersand';
 


### PR DESCRIPTION
GH#7 is related to the old XML::Twig bug RT#86633

In my tests, this crash doesn't happen with latest XML::Twig version (but other problems could pop up, like disappearing ampersand RT#93604) or with my patched XML::Twig 3.44 https://github.com/melmothx/xmltwig/tree/topic/fix-escaping

Upstream says the current #93604 bug will be fixed soon. RT#86633 was superseded by latest release.
